### PR TITLE
Fix aes.key file remain

### DIFF
--- a/main.js
+++ b/main.js
@@ -1060,6 +1060,8 @@ async function startDownload(object, iidx) {
                         let index_path = path.join(dir, 'index.txt');
                         fs.existsSync(index_path) && fs.unlinkSync(index_path);
                         fileSegments.forEach(item => fs.existsSync(item) && fs.unlinkSync(item));
+                        let aesKey_path = path.join(dir, 'aes.key');
+                        fs.existsSync(aesKey_path) && fs.unlinkSync(aesKey_path);
                         fs.rmdirSync(dir);
                     }
                     fs.writeFileSync(pathVideoDB, JSON.stringify(videoDatas));


### PR DESCRIPTION
修正该文件及中间文件夹出现残留的问题。

`error: uncaughtException: Error: ENOTEMPTY: directory not empty, rmdir 'D:\videodownload\…… | uncaughtException`