### PR TITLE
Allow debugging with VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 yarn.lock
 yarn-*
 dist/
-.vscode
 .DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Debug Main Process",
+        "type": "node",
+        "request": "launch",
+        "cwd": "${workspaceFolder}",
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
+        "windows": {
+          "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
+        },
+        "args" : ["."]
+      }
+    ]
+  }


### PR DESCRIPTION
从`.gitignore`来看您可能有自己的配置。但项目应该包含，找出如何调试该项目花费了一些时间。

内容参考自 https://www.electronjs.org/zh/docs/latest/tutorial/debugging-vscode